### PR TITLE
Add support for subtitles to blog posts

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -263,6 +263,11 @@ ol.blog {
     li {
         margin-bottom: $margin-default;
 
+        h3 {
+            font-size: medium;
+            margin: 0;
+        }
+
         span.metadata {
             margin-left: $margin-default;
         }

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -268,6 +268,15 @@ ol.blog {
             margin: 0;
         }
 
+        h4 {
+            font-size: medium;
+            font-weight: normal;
+
+            margin: 0;
+            margin-top: $margin-narrow;
+            margin-left: $margin-narrow;
+        }
+
         span.metadata {
             margin-left: $margin-default;
         }

--- a/templates/newsletter/email.html
+++ b/templates/newsletter/email.html
@@ -31,6 +31,10 @@
                 margin-bottom: 2rem;
             }
 
+            body header .preview-text {
+                display: none;
+            }
+
             body main h3 {
                 margin-top:    2rem;
                 margin-bottom: 1rem;
@@ -90,6 +94,10 @@
     </head>
     <body>
         <header>
+            {% if page.extra.subtitle %}
+                <div class="preview-text">{{ page.extra.subtitle }}</div>
+            {% endif %}
+
             <p>
                 Fornjot is an early-stage project to create a next-generation, code-first CAD application. You are receiving this email because you signed up for the newsletter at the <a href="https://www.fornjot.app/">Fornjot website</a>. Please check the bottom of this email for more information, and a link to unsubscribe.
             </p>

--- a/templates/section.html
+++ b/templates/section.html
@@ -11,6 +11,9 @@
         {% for page in section.pages %}
             <li>
                 <h3><a href="{{ page.path }}">{{ page.title }}</a></h3>
+                {% if page.extra.subtitle %}
+                    <h4>{{ page.extra.subtitle }}</h4>
+                {% endif %}
                 {{ blog::metadata(post=page) }}
             </li>
         {% endfor %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -10,7 +10,7 @@
     <ol class="blog">
         {% for page in section.pages %}
             <li>
-                <a href="{{ page.path }}">{{ page.title }}</a><br />
+                <h3><a href="{{ page.path }}">{{ page.title }}</a></h3>
                 {{ blog::metadata(post=page) }}
             </li>
         {% endfor %}


### PR DESCRIPTION
The main intention here is to have a meaningful preview text in emails, but I figured I can re-use it on the blog page.