### PR TITLE
Fix link in weekly release email

### DIFF
--- a/templates/newsletter/weekly-release.html
+++ b/templates/newsletter/weekly-release.html
@@ -2,6 +2,6 @@
 
 {% block header %}
     <p>
-        This is the announcement for Fornjot's weekly release. If you want to read this in a browser or share it with a friend, please check out <a href="{{ page.permalink }}">the version on the website</a>.
+        This is the announcement for Fornjot's weekly release. If you want to read this in a browser or share it with a friend, please check out <a href="{{ page.permalink | safe }}">the version on the website</a>.
     </p>
 {% endblock %}


### PR DESCRIPTION
Without ` | safe`, the template engine would escape the link, rendering it invalid.