### PR TITLE
Replace link to milestone post with roadmap link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -20,7 +20,7 @@ Want to learn more? Here are some resources you might be interested in:
 
 - [Why the world needs another CAD program](/blog/the-world-needs-another-cad-program/)
 - [The advantages of a code-first approach to CAD](/blog/code-cad-advantages/)
-- [Fornjot's current development priorities](/blog/straight-edges-flat-faces-simple-sketches-full-csg/)
+- [Fornjot's development roadmap](/roadmap/)
 
 
 ### Sponsors

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -66,6 +66,6 @@ This is not an exhaustive list. Please [check out the feature wishlist](https://
 
 <div class="call-to-action">
     <p>
-        <strong>Fornjot is an ambitious project.</strong> How much of that ambition can be realized depends on how sustainable the project can become. If you can, please consider helping out, by <a href="https://github.com/hannobraun/Fornjot">contributing to the project</a>, or by <a href="/sponsor">becoming a sponsor</a>.
+        <strong>Fornjot is an ambitious project.</strong> How much of that ambition can be realized depends on how sustainable the project can become. If you can, please consider helping out, by <a href="https://github.com/hannobraun/Fornjot">contributing to the project</a>, or by <a href="/funding/">becoming a sponsor</a>.
     </p>
 </div>


### PR DESCRIPTION
The original link was added there before the roadmap page existed. I think the roadmap is a more suitable target.