### PR TITLE
Remove Matrix ID from email footer

### DIFF
--- a/templates/newsletter/email.html
+++ b/templates/newsletter/email.html
@@ -147,7 +147,6 @@
                         Germany<br />
                         <br />
                         <a href="mailto:hanno@braun-odw.eu">hanno@braun-odw.eu</a><br />
-                        <a href="https://matrix.to/#/@hanno:braun-odw.eu">@hanno:braun-odw.eu</a>
                     </address>
                 </div>
                 <div class="unsubscribe">


### PR DESCRIPTION
I'm no longer using this one, and I'm not longer so invested in Matrix that I want to add the new one here.