### PR TITLE
Remove "Sponsor" link in menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,6 @@
                     <li><a href="/">About</a></li>
                     <li><a href="/blog">Blog</a></li>
                     <li><a href="/community">Community</a></li>
-                    <li><a class="highlight" href="https://github.com/sponsors/hannobraun">Sponsor ↪</a></li>
                     <li><a href="https://github.com/hannobraun/fornjot">GitHub ↪</a></li>
                 </ul>
             </nav>


### PR DESCRIPTION
I missed this earlier, when I removed the other references to GitHub Sponsors.

Follow-up to https://github.com/hannobraun/www.fornjot.app/pull/318