### PR TITLE
Remove reference to GitHub Sponsors in footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -58,10 +58,6 @@
                 <br />
                 <a href="mailto:hello@hannobraun.com">hello@hannobraun.com</a><br />
             </address>
-
-            <strong class="call-to-action">
-                Please consider supporting Fornjot by <a href="https://github.com/sponsors/hannobraun">sponsoring me</a>.
-            </strong>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
I keep finding more.

Follow-up to https://github.com/hannobraun/www.fornjot.app/pull/318 and https://github.com/hannobraun/www.fornjot.app/pull/319.